### PR TITLE
Add @types/node to pacakge.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^22.13.5",
         "release-it": "^17.11.0",
         "style-dictionary": "^3.9.2",
         "style-dictionary-utils": "^2.0.7",
@@ -1086,6 +1087,15 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -4940,6 +4950,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "style-dictionary-utils": "^2.0.7"
   },
   "devDependencies": {
+    "@types/node": "^22.13.5",
     "release-it": "^17.11.0",
     "style-dictionary": "^3.9.2",
     "style-dictionary-utils": "^2.0.7",


### PR DESCRIPTION
以下のビルドエラーが発生したので修正します。

```
✖ npm run build
ERROR error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
Error: error occurred in dts build
    at Worker.<anonymous> (/home/runner/work/style-dictionary-formatter/style-dictionary-formatter/node_modules/tsup/dist/index.js:1541:26)
    at Worker.emit (node:events:518:28)
    at MessagePort.<anonymous> (node:internal/worker:268:53)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:[23](https://github.com/serendie/style-dictionary-formatter/actions/runs/13562997794/job/37909776022#step:7:24):28)
```