### PR TITLE
ハイフンがついたテーマ名をクォートする

### DIFF
--- a/src/utils/getTypeScriptType.ts
+++ b/src/utils/getTypeScriptType.ts
@@ -4,5 +4,8 @@ const { getTypeScriptType: _getTypeScriptType } = StyleDictionary.formatHelpers;
 export function getTypeScriptType(value: any) {
   const type = _getTypeScriptType(value);
   // 01や02などゼロから始まる数値リテラルになっている箇所をクオートする
-  return type.replace(/\b0\d+\b/g, (match) => `"${match}"`);
+  // konjo-darkなどハイフン付きキーもクオートする
+  return type
+    .replace(/\b0\d+\b/g, (match) => `"${match}"`)
+    .replace(/(?<=[{,]\s*)(\w+-\w+)(?=\s*:)/g, (match) => `"${match}"`);
 }

--- a/tests/formatter/utils.test.ts
+++ b/tests/formatter/utils.test.ts
@@ -18,4 +18,15 @@ describe("getTypeScriptType", () => {
       `{ "01": { value: number }, "02": { value: number } }`
     );
   });
+
+  it("ハイフン付きキーをクオートする", () => {
+    const input = {
+      konjo: { value: "string" },
+      "konjo-dark": { value: "string" },
+    };
+    const output = getTypeScriptType(input);
+    expect(output).toEqual(
+      `{ konjo: { value: string }, "konjo-dark": { value: string } }`
+    );
+  });
 });


### PR DESCRIPTION
viteでビルドする時に型エラーが発生するため変更が必要です